### PR TITLE
Remove social icons from the header

### DIFF
--- a/contact_me.html
+++ b/contact_me.html
@@ -25,20 +25,7 @@
 <body>
     <header id="titlebar">
         <div id="titlebar_container">
-            <span class="brand">
-                <span class="social">
-                    <a class="icon" href="mailto:stephenwelchva@gmail.com" aria-label="Email">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
-                    </a>
-                    <a class="icon" href="https://linkedin.com/in/stephenwelchva" aria-label="LinkedIn" target="_blank" rel="noopener">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>
-                    </a>
-                    <a class="icon" href="https://x.com/_ildsjel" aria-label="X (formerly Twitter)" target="_blank" rel="noopener">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-                    </a>
-                </span>
-                <h1> Stephen Welch </h1>
-            </span>
+            <h1> Stephen Welch </h1>
             <nav>
                 <a href="index.html"> Home </a>
                 <!-- <a href="projects.html"> Projects </a> -->

--- a/css/main.css
+++ b/css/main.css
@@ -47,7 +47,6 @@ section {
 header#titlebar {
     text-align: center;
     margin-bottom: 5%;
-    --title-font: clamp(2.25rem, 11vw, 4.5em);
 }
 
 header#titlebar #titlebar_container {
@@ -61,7 +60,7 @@ header#titlebar #titlebar_container {
 
 header#titlebar h1 {
     /* scales down on narrow screens so the name stays on one line */
-    font-size: var(--title-font);
+    font-size: clamp(2.25rem, 11vw, 4.5em);
     margin: 0;
     padding-right: 1%;
     white-space: nowrap;
@@ -84,43 +83,6 @@ header#titlebar nav a:active {
 
 header#titlebar nav a[aria-current="page"] {
     font-weight: bold;
-}
-
-header#titlebar .brand {
-    /* expose the title's baseline to the row, with icons centered beside it */
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5em;
-    align-self: baseline;
-}
-
-header#titlebar .social {
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: center;
-    /* size icons relative to the title so the stack fits within its height */
-    font-size: var(--title-font);
-    gap: 0.05em;
-}
-
-header#titlebar a.icon {
-    display: inline-flex;
-    margin: 0;
-    transition: transform 0.2s ease;
-    transform-origin: center center;
-    will-change: transform;
-}
-
-header#titlebar a.icon:hover,
-header#titlebar a.icon:active {
-    transform: scale(1.17);
-}
-
-header#titlebar a.icon svg {
-    /* three icons + two gaps ≈ 0.7em ≈ cap height of the title */
-    width: 0.2em;
-    height: 0.2em;
-    display: block;
 }
 
 .resume-download {

--- a/index.html
+++ b/index.html
@@ -25,20 +25,7 @@
 <body>
     <header id="titlebar">
         <div id="titlebar_container">
-            <span class="brand">
-                <span class="social">
-                    <a class="icon" href="mailto:stephenwelchva@gmail.com" aria-label="Email">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
-                    </a>
-                    <a class="icon" href="https://linkedin.com/in/stephenwelchva" aria-label="LinkedIn" target="_blank" rel="noopener">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>
-                    </a>
-                    <a class="icon" href="https://x.com/_ildsjel" aria-label="X (formerly Twitter)" target="_blank" rel="noopener">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-                    </a>
-                </span>
-                <h1> Stephen Welch </h1>
-            </span>
+            <h1> Stephen Welch </h1>
             <nav>
                 <a href="index.html" aria-current="page"> Home </a>
                 <!-- <a href="projects.html"> Projects </a> -->

--- a/resume.html
+++ b/resume.html
@@ -25,20 +25,7 @@
 <body>
     <header id="titlebar">
         <div id="titlebar_container">
-            <span class="brand">
-                <span class="social">
-                    <a class="icon" href="mailto:stephenwelchva@gmail.com" aria-label="Email">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
-                    </a>
-                    <a class="icon" href="https://linkedin.com/in/stephenwelchva" aria-label="LinkedIn" target="_blank" rel="noopener">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>
-                    </a>
-                    <a class="icon" href="https://x.com/_ildsjel" aria-label="X (formerly Twitter)" target="_blank" rel="noopener">
-                        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-                    </a>
-                </span>
-                <h1> Stephen Welch </h1>
-            </span>
+            <h1> Stephen Welch </h1>
             <nav>
                 <a href="index.html"> Home </a>
                 <!-- <a href="projects.html"> Projects </a> -->


### PR DESCRIPTION
Removes the Email/LinkedIn/X social icons from the header for now, per request.

## Change
- Removed the `brand`/`social`/`icon` markup from the header on `index.html`, `resume.html`, `contact_me.html` — the header is now just the title + nav.
- Removed the associated CSS (`.brand`, `.social`, `a.icon`, icon SVG sizing) and the `--title-font` variable (inlined the `clamp()` back into the `h1`).

## Kept
- The title and nav still share a baseline (the flex `align-items: baseline` layout), and the `scrollbar-gutter` fix remains in place.

## Verification
- Rendered all pages at desktop (1280) and mobile (390); header shows just "Stephen Welch" + nav, baseline-aligned, no icons. No leftover icon references in HTML or CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nx6FDKNWfbx1NPKXiZWbA)_