### PR TITLE
Use YouTube video as the Apollo Humanoid Robot thumbnail

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,7 @@
                     <span class="content">Deploying reinforcement learning on humanoid robots</span>
                 </div>
             </details>
-            <img src="media/alpha.jpg" alt="Apollo humanoid robot">
-            <!-- <lite-youtube videoid="TfcWNZO-DBk" playlabel="YouTube video player"></lite-youtube> -->
+            <lite-youtube videoid="iPyxwELiD9Q" playlabel="YouTube video player"></lite-youtube>
         </article>
         <article class="project">
             <details open>


### PR DESCRIPTION
Makes the [Apollo humanoid robot video](https://www.youtube.com/watch?v=iPyxwELiD9Q) the thumbnail for the "Apollo Humanoid Robot" project card.

## Change
- Replaced the static `media/alpha.jpg` image in the Apollo card with a `<lite-youtube videoid="iPyxwELiD9Q">` embed — the same component already used for the Air Combat, Golden Horde, and Deep RL cards. Clicking it plays the video inline.

## Notes
- `alpha.jpg` is still referenced as the page's Open Graph image, so it stays in the repo.
- Verified the card renders the `lite-youtube` element with the correct video ID. The poster thumbnail can't load in the headless sandbox (YouTube's image CDN is blocked there), but it will display normally on the live site like the other project videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nx6FDKNWfbx1NPKXiZWbA)_