### PR TITLE
Update About Me copy/links and add Jax badge to Apollo

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@
     <section class="about">
         <h2> About Me </h2>
         <p>
-            I'm a software engineer at <a href="https://apptronik.com">Apptronik</a>, where I deploy reinforcement learning on humanoid robots.<br>
+            I'm a reinforcement learning engineer at <a href="https://apptronik.com">Apptronik</a>, where I focus on making robots move less like robots and more like humans.<br>
             Previously, I received an MS in Electrical Engineering from Virginia Tech, where I studied the intersection of control theory and deep reinforcement
-            learning at the <a href="https://www.trecvt.org">Terrestrial Robotics and Controls Lab</a>.<br>
+            learning at the Terrestrial Robotics and Controls Lab.<br>
             Before that, I interned at <a href="https://www.shield.ai">Shield AI</a>, where I built RL systems to control and coordinate things that fly.
             <br>
             For my undergraduate studies, I majored in <a
-                href="https://catalog.vt.edu/undergraduate/college-engineering/electrical-computer-engineering/computer-engineering-bs-controls-robotics-autonomy/">Controls,
+                href="https://catalog.vt.edu/undergraduate/college-engineering/electrical-computer-engineering/computer-engineering-bs-controls-robotics-autonomy-option/">Controls,
                 Robotics & Autonomy</a> with a degree in Computer Engineering.
         </p>
     </section>
@@ -57,7 +57,7 @@
                     <div class="where">Apptronik</div>
                     <span>/</span>
                     <div class="when">Present</div>
-                    <span class="with">Python</span><span class="with">Pytorch</span><span class="with">C++</span>
+                    <span class="with">Python</span><span class="with">Pytorch</span><span class="with">Jax</span><span class="with">C++</span>
                 </div>
                 <div class="detail">
                     <span class="content">Deploying reinforcement learning on humanoid robots</span>


### PR DESCRIPTION
Home-page content updates to the "About Me" section and the Apollo project card.

## Changes
- **About Me, first sentence** → "I'm a reinforcement learning engineer at Apptronik, where I focus on making robots move less like robots and more like humans." (Apptronik link preserved.)
- **Removed the TREC Lab website link** — "Terrestrial Robotics and Controls Lab" is now plain text.
- **Updated the "Controls, Robotics & Autonomy" link** to the `…-controls-robotics-autonomy-option/` catalog URL.
- **Added a `Jax` badge** to the Apollo Humanoid Robot card (now Python · Pytorch · Jax · C++).

## Verification
- Rendered the home page: new copy shows, TREC text is no longer a link, the Controls link resolves to the new URL, and the Apollo badges read `["Python","Pytorch","Jax","C++"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nx6FDKNWfbx1NPKXiZWbA)_