### PR TITLE
Remove résumé download link, leaving only the embed

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -35,9 +35,6 @@
         </div>
     </header>
 
-    <p class="resume-download">
-        <a href="resume.pdf" download>Download résumé (PDF)</a>
-    </p>
     <iframe src="resume.pdf" width="100%" height="960px" title="Stephen Welch résumé"></iframe>
 </body>
 


### PR DESCRIPTION
Removes the "Download résumé (PDF)" link above the résumé embed, so the page shows only the inline PDF.

## Change
- Deleted the `<p class="resume-download">…</p>` block from `resume.html`. The `<iframe>` embed is now the only content in the body.

## Note
- The `.resume-download` CSS rule in `css/main.css` is now unused. I left it in place to avoid a merge conflict with the open remove-icons PR (#13), which also edits `main.css` nearby. Happy to strip it in a quick follow-up once the main.css PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nx6FDKNWfbx1NPKXiZWbA)_